### PR TITLE
Feature/bump meson to 1.7.0

### DIFF
--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -29,11 +29,24 @@ jobs:
           if "${{ github.event_name }}" == "pull_request":
             operating_system = [ 'mesonbuild/ubuntu-rolling', 'mesonbuild/arch:latest' ]
             toolchain = [ 'gcc|12.3.Rel1', 'gcc|10.3-2021.07', 'gcc|13.2.Rel1', 'gcc|14.2.Rel1' ]
-            config = [ 'nucleo_u5a5_autotest', 'nucleo_wb55_autotest', 'nucleo_u5a5_nooutput', 'stm32f429i_disc1_debug', 'stm32f429i_disc1_release', 'stm32f429i_disc1_autotest' ]
+            config = [
+              { 'name': 'nucleo_u5a5_autotest', 'cpu': 'cm33', 'triple': 'thumbv8m.main-none-eabi' },
+              { 'name': 'nucleo_u5a5_nooutput', 'cpu': 'cm33', 'triple': 'thumbv8m.main-none-eabi' },
+              { 'name': 'nucleo_wb55_autotest', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },
+              { 'name': 'stm32f429i_disc1_debug', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },
+              { 'name': 'stm32f429i_disc1_release', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },
+              { 'name': 'stm32f429i_disc1_autotest', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },
+            ]
           else:
             operating_system = [ 'mesonbuild/ubuntu-rolling' ]
             toolchain = [ 'gcc|13.2.Rel1' ]
-            config = [ 'nucleo_u5a5_autotest', 'nucleo_wb55_autotest', 'stm32f429i_disc1_debug', 'nucleo_l476rg_debug', 'nucleo_f401re' ]
+            config = [
+              { 'name': 'nucleo_u5a5_autotest', 'cpu': 'cm33', 'triple': 'thumbv8m.main-none-eabi' },
+              { 'name': 'nucleo_wb55_autotest', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },
+              { 'name': 'stm32f429i_disc1_debug', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },
+              { 'name': 'nucleo_l476rg_debug', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },
+              { 'name': 'nucleo_f401re', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },
+            ]
           with open(os.environ['GITHUB_OUTPUT'], 'w') as gh_out:
             gh_out.write(f"operating_system={operating_system}\n")
             gh_out.write(f"toolchain={toolchain}\n")
@@ -99,7 +112,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          targets: thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf
+          targets: ${{ matrix.config.triple }}
           components: clippy,rustfmt
       - name: Setup C toolchain
         uses: camelot-os/action-setup-compiler@v1
@@ -113,13 +126,13 @@ jobs:
           pip install -r requirements.txt
       - name: defconfig
         run: |
-          defconfig configs/${{matrix.config}}_defconfig
+          defconfig configs/${{ matrix.config.name }}_defconfig
       - name: Meson Build
         uses: camelot-os/action-meson@v1
         with:
-          cross_files: ${{ format('{0}/{1}', env.MESON_CROSS_FILES, 'arm-none-eabi-gcc.ini') }}
+          cross_files: ${{ format('{0}/{1}-none-eabi-gcc.ini', env.MESON_CROSS_FILES, matrix.config.cpu) }}
           actions: '["prefetch", "setup", "compile"]'
-          options: '-Dconfig=.config -Ddts=dts/examples/${{ matrix.config }}.dts -Ddts-include-dirs=dts'
+          options: '-Dconfig=.config -Ddts=dts/examples/${{ matrix.config.name }}.dts -Ddts-include-dirs=dts'
       - name: Meson postcheck
         if: failure()
         run: |
@@ -169,7 +182,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          targets: thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf
+          targets: thumbv7em-none-eabi
           components: clippy,rustfmt
       - name: deploy local deps
         run: |
@@ -180,7 +193,7 @@ jobs:
       - name: Meson Build
         uses: camelot-os/action-meson@v1
         with:
-          cross_files: ${{ format('{0}/{1}', env.MESON_CROSS_FILES, 'arm-none-eabi-gcc.ini') }}
+          cross_files: ${{ format('{0}/{1}', env.MESON_CROSS_FILES, 'cm4-none-eabi-gcc.ini') }}
           actions: '["prefetch", "setup", "test"]'
           options: '-Dconfig=.config -Ddts=dts/examples/stm32f429i_disc1_debug.dts -Ddts-include-dirs=dts -Dwith_tests=true -Db_coverage=false -Doptimization=0'
       - name: Meson postcheck

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,7 +60,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          targets: thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf
+          targets: thumbv8m.main-none-eabi
           components: clippy,rustfmt
       - name: Setup C toolchain
         uses: camelot-os/action-setup-compiler@v1
@@ -79,7 +79,7 @@ jobs:
       - name: Meson Build
         uses: camelot-os/action-meson@v1
         with:
-          cross_files: ${{ format('{0}/{1}', env.MESON_CROSS_FILES, 'arm-none-eabi-gcc.ini') }}
+          cross_files: ${{ format('{0}/{1}', env.MESON_CROSS_FILES, 'cm33-none-eabi-gcc.ini') }}
           actions: '["prefetch", "setup", "compile"]'
           options: '-Dconfig=.config -Ddts=dts/examples/nucleo_u5a5_autotest.dts -Ddts-include-dirs=dts'
       - name: Meson postcheck

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -55,7 +55,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          targets: thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf
+          targets: thumbv8m.main-none-eabi
           components: clippy,rustfmt
       - name: Setup C toolchain
         uses: camelot-os/action-setup-compiler@v1
@@ -72,7 +72,7 @@ jobs:
       - name: Meson Build
         uses: camelot-os/action-meson@main
         with:
-          cross_files: ${{ format('{0}/{1}', env.MESON_CROSS_FILES, 'arm-none-eabi-gcc.ini') }}
+          cross_files: ${{ format('{0}/{1}', env.MESON_CROSS_FILES, 'cm33-none-eabi-gcc.ini') }}
           actions: '["prefetch", "setup"]'
           options: '-Dconfig=.config -Ddts=dts/examples/nucleo_u5a5_autotest.dts -Ddts-include-dirs=dts -Dwith_proof=true'
       - name: run framaC

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2024 Ledger SAS
 # SPDX-License-Identifier: Apache-2.0
 
-meson~=1.4.0
+meson>=1.7.0
 ninja
 kconfiglib~=14.1.0
 sphinx_rtd_theme

--- a/support/arch/asm-cortex-m/meson.build
+++ b/support/arch/asm-cortex-m/meson.build
@@ -5,14 +5,51 @@ target_cpu = 'cortex-@0@'.format(kconfig_data.get_unquoted('CONFIG_ARCH_ARM_CORT
 target_has_fpu = kconfig_data.get('CONFIG_HAS_FPU', 0) == 1
 target_use_fpu = kconfig_data.get('CONFIG_FPU_SOFT_ABI', 0) != 1
 
+c_compiler = meson.get_compiler('c')
 
-compiler = meson.get_compiler('c')
 target_rust = kconfig_data.get_unquoted('CONFIG_RUSTC_TARGET')
 target_rustargs = [
-    '--target=' + target_rust,
     '-Ctarget-cpu='+ target_cpu,
-    '-Clinker=' + compiler.cmd_array()[0],
+    '-Clinker=' + c_compiler.cmd_array()[0],
 ]
+
+# Implicit rustargs are ones set from meson cross file
+# Those args do not need to be add to project args
+# But need to be exported for rust sdk.
+implicit_target_rustargs = []
+
+if with_uapi_opt
+    add_languages('rust', native: false, required: true)
+    rust_compiler = meson.get_compiler('rust')
+
+    # rustc target must be defined in cross file
+    # check consistency between `.config` selected target and used cross-file
+    rust_target_opt = '--target'
+    target_rust_cross_file = ''
+
+    # XXX:
+    #  Only --target is handled here
+    #  Other implicit args won't be exported.
+    #  If needed, open a Issue on Github.
+    foreach arg: rust_compiler.cmd_array()
+        if arg.startswith(rust_target_opt)
+            implicit_target_rustargs += [arg]
+            target_rust_cross_file = arg.split('=')[1]
+        endif
+    endforeach
+
+    if target_rust_cross_file == ''
+        warning('rustc target is missing from cross file')
+        target_rustargs += ['--target=' + target_rust]
+    elif target_rust_cross_file != target_rust
+        error(
+            'rust target mismatch (@0@ / @1@) check .config and/or cross file'.format(
+                target_rust,
+                target_rust_cross_file
+            )
+        )
+    endif
+endif
 
 target_cflags = [
     '-mcpu=' + target_cpu,
@@ -74,6 +111,7 @@ summary(
     {
         'cflags': target_cflags,
         'rustargs': target_rustargs,
+        'implicit rustargs': implicit_target_rustargs,
     },
     bool_yn: true,
     section: 'Target specific compile args'

--- a/uapi/meson.build
+++ b/uapi/meson.build
@@ -119,7 +119,7 @@ rustargs_template = files('rustargs.in')
 rustargs_file = configure_file(
     input: rustargs_template,
     output: '@BASENAME@',
-    command: [jinja_cli, '@INPUT@', '--define', 'rustargs', ' '.join(target_rustargs), '-o', '@OUTPUT@'],
+    command: [jinja_cli, '@INPUT@', '--define', 'rustargs', ' '.join(implicit_target_rustargs + target_rustargs), '-o', '@OUTPUT@'],
     install: true,
     install_dir: get_option('datadir') / 'cargo',
     install_tag: 'data',


### PR DESCRIPTION
Rustc sanity check for `no_std` target is now available.
Need the following in cross-file:
 - `kernel = 'none'`
 - `rustc = [ 'rustc', '--target=<target llvm triple>]`

see: https://github.com/camelot-os/meson-cross-files/commit/055750489c26853ee3c46a4188a4676ba1c0cbb6

As target is now defined in cross file, fetch this from cross file and check consistency over kconfig.

Need to rebase once #9 merged