### PR TITLE
fix: adding missing hsi48 clock source config for RNG usage

### DIFF
--- a/dts/examples/nucleo_u5a5.dts
+++ b/dts/examples/nucleo_u5a5.dts
@@ -57,6 +57,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+       status = "okay";
+};
+
 &clk_hse {
 	status = "okay";
 };

--- a/dts/examples/nucleo_u5a5_autotest.dts
+++ b/dts/examples/nucleo_u5a5_autotest.dts
@@ -145,6 +145,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+       status = "okay";
+};
+
 &clk_hse {
 	status = "okay";
 };


### PR DESCRIPTION
Note: Tested on nucleo-u5a5 with HW RNG.

Fixes #20 