### PR TITLE
Removing check for dunamai binary in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,8 +40,6 @@ fs = import('fs')
 pymod = import('python')
 ssmod = import('sourceset')
 
-
-dunamai = find_program('dunamai', required: true)
 py3 = pymod.find_installation('python3')
 
 kconfig_file = meson.current_source_dir() / 'Kconfig'


### PR DESCRIPTION
dunamai is no more used to get back semversioning from gconf