### PR TITLE
enhancement: support logo bootup in serial mode

### DIFF
--- a/kernel/src/managers/Kconfig
+++ b/kernel/src/managers/Kconfig
@@ -79,6 +79,20 @@ config DEBUG_COLORS
 	  Activate ANSI coloration on serial console for kernel debugging
 	  output. Userspace log is not impacted
 
+config DEBUG_LOGO
+	bool "Display kernel logo on startup"
+	default y
+	help
+	  Display the kernel logo on startup, if the console supports it.
+	  This is only available for debug output on usart.
+
+config DEBUG_LOGO_COLORED
+	bool "Display kernel logo in color"
+	default n
+	help
+	  Display the kernel logo in color, if the console supports it.
+	  This is only available for debug output on usart.
+
 if DEBUG_COLORS
 
 choice

--- a/kernel/src/managers/debug/debug.c
+++ b/kernel/src/managers/debug/debug.c
@@ -10,7 +10,7 @@
 #include <sentry/arch/asm-cortex-m/semihosting.h>
 #endif
 #include "log.h"
-
+#include "logo.h"
 /**
  * @brief probe the debug backend
  *
@@ -31,6 +31,7 @@ kstatus_t mgr_debug_init(void)
 #endif
     dbgbuffer_flush();
 #if CONFIG_DEBUG_OUTPUT_USART
+    logo_print();
 end:
 #endif
     return status;

--- a/kernel/src/managers/debug/logo.c
+++ b/kernel/src/managers/debug/logo.c
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2025 H2Lab Development Team
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sentry/managers/debug.h>
+
+
+#if defined(CONFIG_DEBUG_LOGO)
+#if defined(CONFIG_DEBUG_LOGO_COLORED)
+/* ASCII standard echapment codes for foreground characters */
+#define COLOR_FG_BLUE   "\e[0;34m"
+#define COLOR_FG_RESET  "\e[0m"
+#else
+#define COLOR_FG_BLUE
+#define COLOR_FG_RESET
+#endif
+
+static const char * const h2lab[] = {
+"                    ......." COLOR_FG_BLUE "####" COLOR_FG_RESET "..\n",
+"              ......." COLOR_FG_BLUE "*########" COLOR_FG_RESET "........\n",
+"          ....." COLOR_FG_BLUE "*##############" COLOR_FG_RESET "....=" COLOR_FG_BLUE "#######" COLOR_FG_RESET "..\n",
+"          ..." COLOR_FG_BLUE "#######" COLOR_FG_RESET "....." COLOR_FG_BLUE "*##@##########*" COLOR_FG_RESET ".....\n",
+"             ..........." COLOR_FG_BLUE "+##########" COLOR_FG_RESET "........\n",
+"       ...       ...." COLOR_FG_BLUE "##########" COLOR_FG_RESET "........\n",
+"      .." COLOR_FG_BLUE "###" COLOR_FG_RESET "...       .............       +++++++\n",
+"     ..." COLOR_FG_BLUE "####" COLOR_FG_RESET "......                   +++++++++++\n",
+"      .." COLOR_FG_BLUE "####" COLOR_FG_RESET "....." COLOR_FG_BLUE "##" COLOR_FG_RESET "..            +++++++++++++++\n",
+"      .." COLOR_FG_BLUE "####" COLOR_FG_RESET "....:" COLOR_FG_BLUE "####" COLOR_FG_RESET ".         ++++++++++++ ++++\n",
+"      ..." COLOR_FG_BLUE "###" COLOR_FG_RESET "-...." COLOR_FG_BLUE "####" COLOR_FG_RESET "..       ++++++++++++++++++\n",
+"      ..." COLOR_FG_BLUE "####" COLOR_FG_RESET "...:" COLOR_FG_BLUE "####" COLOR_FG_RESET "...     +++++++++++++ +++++\n",
+"      ..." COLOR_FG_BLUE "#######" COLOR_FG_RESET "." COLOR_FG_BLUE "####" COLOR_FG_RESET "....    ++++ ++++  ++ ++ ++\n",
+"      ..." COLOR_FG_BLUE "############" COLOR_FG_RESET "....   +++++ +++++ ++++++++\n",
+"      ..." COLOR_FG_BLUE "############" COLOR_FG_RESET "....   +++++++++++++  +++++\n",
+"       .." COLOR_FG_BLUE "####" COLOR_FG_RESET "..." COLOR_FG_BLUE "#####" COLOR_FG_RESET "....   ++++ ++ ++ ++++++++\n",
+"        ." COLOR_FG_BLUE "####" COLOR_FG_RESET "...." COLOR_FG_BLUE "####" COLOR_FG_RESET "....   ++++ ++  +++++++++\n",
+"         ." COLOR_FG_BLUE "###" COLOR_FG_RESET "...." COLOR_FG_BLUE "####" COLOR_FG_RESET "....   ++++ ++++++++++++\n",
+"          ......." COLOR_FG_BLUE "####" COLOR_FG_RESET "....   ++++++++++++++++\n",
+"             ...." COLOR_FG_BLUE "####" COLOR_FG_RESET "....   ++++++++++++++\n",
+"               ..." COLOR_FG_BLUE "###" COLOR_FG_RESET "....   +++++++++++\n",
+"                  ......    ++++++++\n",
+"                              ++\n",
+NULL,
+};
+
+void logo_print(void) {
+    // Print the h2lab ASCII art
+    size_t i = 0;
+    while (h2lab[i] != NULL) {
+        printk("%s", h2lab[i++]);
+    }
+}
+#else
+void logo_print(void) {
+    // Do nothing if not in debug or autotest mode
+}
+#endif

--- a/kernel/src/managers/debug/logo.h
+++ b/kernel/src/managers/debug/logo.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 H2Lab Development Team
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KERNEL_MANAGERS_DEBUG_LOGO_H
+#define KERNEL_MANAGERS_DEBUG_LOGO_H
+
+void logo_print(void);
+
+#endif /*!KERNEL_MANAGERS_DEBUG_LOGO_H*/

--- a/kernel/src/managers/debug/meson.build
+++ b/kernel/src/managers/debug/meson.build
@@ -6,4 +6,5 @@ managers_source_set.add(files(
     'log_lexer.c',
     'log.c',
     'debug.c',
+    'logo.c',
 ))


### PR DESCRIPTION
Useless but fun: adding H2Lab logo at bootup.
The logo printing requires:
- to be in DEBUG or AUTOTEST mode (deactivated in RELEASE mode) (default=y in these mode)
- to have the USART configured as OUTPUT (deactivated in semihosting mode)
The logo can use FG colors (default=n). colors can be deactivated separatedly.

![Screenshot from 2025-06-27 08-44-47](https://github.com/user-attachments/assets/e8ff85ac-6c65-4ac6-9f1c-1e0d7c420489)

See Kconfig update for associated flags.