### PR TITLE
rp2350: adding basics about rp2350 kconfig & svd inputs

### DIFF
--- a/kernel/src/arch/Kconfig
+++ b/kernel/src/arch/Kconfig
@@ -14,6 +14,9 @@ config ARCH_ARM_CORTEX_M
 
 endchoice
 
+# always supported
+rsource'asm-generic/Kconfig'
+
 if ARCH_ARM_CORTEX_M
 rsource 'asm-cortex-m/Kconfig'
 endif

--- a/kernel/src/arch/asm-cortex-m/Kconfig
+++ b/kernel/src/arch/asm-cortex-m/Kconfig
@@ -52,15 +52,6 @@ config ARCH_ARM_CORTEX_M35P
 	bool
 	select ARCH_ARM_ARMV8MML
 
-config HAS_DCACHE
-	bool
-
-config HAS_ICACHE
-	bool
-
-config HAS_FPU
-	bool
-
 config HAS_FPU_VFPV3
 	bool
 
@@ -97,12 +88,6 @@ config HAS_NVIC
 config THUMB
 	bool
 
-config LITTLE_ENDIAN
-	bool
-
-config BIG_ENDIAN
-	bool
-
 config HAS_DWT
 	bool
 
@@ -118,6 +103,19 @@ config HAS_FLASH_DUAL_BANK
 config SOC_FAMILY_STM32
 	bool
 	select LITTLE_ENDIAN
+
+# this very name can be set in both ARM and RISC-V mode, as the corresponding
+# Arch-specific Kconfig files are never included in the same configuration
+config SOC_SUBFAMILY_RP23XX
+	bool
+	select ARCH_ARM_CORTEX_M33
+	select SOC_FAMILY_RPI_PICO
+	select HAS_FPU
+	select HAS_FPU_FPV5
+	select HAS_MPU
+	select HAS_MPU_PMSA_V8
+	help
+	  RP23XX subfamily, in ARM mode, is based on Cortex-M33
 
 config SOC_SUBFAMILY_STM32F4
 	bool
@@ -237,6 +235,7 @@ config ARCH_SOCNAME
 	default "STM32U5A9" if ARCH_MCU_STM32U5A9
 	default "STM32U5FX" if ARCH_MCU_STM32U5FX
 	default "STM32U5GX" if ARCH_MCU_STM32U5GX
+	default "RP2350" if ARCH_MCU_RP2350
 
 # User-accessible selectors
 
@@ -283,6 +282,10 @@ config ARCH_MCU_STM32U5A5
 config ARCH_MCU_STM32U5A9
 	bool "STM32U5A9"
 	select SOC_SUBFAMILY_STM32U59_Ax
+
+config ARCH_MCU_RP2350
+	bool "RP2350"
+	select SOC_SUBFAMILY_RP23XX
 
 endchoice
 

--- a/kernel/src/arch/asm-generic/Kconfig
+++ b/kernel/src/arch/asm-generic/Kconfig
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 H2Lab Development Team
+# SPDX-License-Identifier: Apache-2.0
+
+# Endianess is not arch-specific, but is defined here for consistency
+# with various arches, and to allow SoC-specific selection
+config LITTLE_ENDIAN
+	bool
+
+config BIG_ENDIAN
+	bool
+
+# data and instruction caches are not mandatory, but are
+# commonly found in most SoCs for various architectures
+config HAS_DCACHE
+	bool
+
+config HAS_ICACHE
+	bool
+
+# Floating Point Unit (FPU) is not mandatory, but is
+# commonly found in most SoCs for various architectures
+config HAS_FPU
+	bool
+
+# raspberry pi Pico SoC family may be cortex-m or RISC-V based, and as such is
+# selectable in both ARM and RISC-V modes
+config SOC_FAMILY_RPI_PICO
+	bool
+	select LITTLE_ENDIAN
+	select HAS_DCACHE
+	select HAS_ICACHE

--- a/kernel/src/drivers/smp/sio/meson.build
+++ b/kernel/src/drivers/smp/sio/meson.build
@@ -3,13 +3,18 @@
 
 sio_drv_sources = files(
     'cpuid.c',
-    'doorbell.c',
-    'fifo.c',
 )
 
-sio_prv_headers = files(
-    'sio_private.h',
+sio_h = custom_target('gen_sio',
+    input: peripheral_defs_in,
+    output: '@0@_defs.h'.format('sio'),
+    depends: [ svd_json ],
+    command: [
+        jinja_cli, '-d', svd_json, '-o', '@OUTPUT@', '--define', 'NAME',
+       'SIO',
+       '@INPUT@'
+    ],
 )
 
 bsp_source_set.add(sio_drv_sources)
-bsp_private_header_set.add(sio_prv_headers)
+bsp_private_header_set.add(sio_h)


### PR DESCRIPTION
- preparing support for SVD-based rp2350 platform support
- adding RP2350 SoC with support for dual RV32I/ARM configuration (note the RV32 Kconfig input is to be made separatedly in another PR)