### PR TITLE
build: adding experimental marker for SMP mode

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -58,8 +58,12 @@ config BUILD_TARGET_AUTOTEST
 	select SECU_LOOP_DBLE_IDX
 endchoice
 
+config EXPERIMENTAL_MODE
+    bool
+    default n
+
 config WITH_SMP_SUPPORT
-    bool "Support for SMP architecture"
+    bool "Support for SMP architecture (EXPERIMENTAL)"
     default n
     help
       In SMP mode, the kernel can be spawned in parallel in multiple cores at the
@@ -71,8 +75,10 @@ config WITH_SMP_SUPPORT
         their core-assignation being dependent of the selected scheduler
       - all kernel code after bootup must be reentrant, using hardware SMP-related locks
         if needed for system-wide impacting codes (e.g. using spin locking)
+    select EXPERIMENTAL_MODE
 
 if WITH_SMP_SUPPORT
+
 
 config SMP_CORES_NUMBER
     int "number of SMP cores"

--- a/kernel/src/drivers/smp/Kconfig
+++ b/kernel/src/drivers/smp/Kconfig
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 H2Lab Development Team
 # SPDX-License-Identifier: Apache-2.0
 
-menu "SMP-related IPs"
+menu "SMP-related IPs (EXPERIMENTAL)"
 	depends on WITH_SMP_SUPPORT
 
 config HAS_SIO

--- a/kernel/src/startup/entrypoint.c
+++ b/kernel/src/startup/entrypoint.c
@@ -35,6 +35,7 @@ __attribute__((noreturn)) void _entrypoint(void)
 {
 #ifdef CONFIG_HAS_SMP_SUPPORT
     size_t cpuid = 0;
+    /* XXX: this part is EXPERIMENTAL and should not, by now, be used in production */
     smp_get_cpuid(&cpuid);
     if (unlikely(cpuid >= SMP_CORES_NUMBER)) {
         do {
@@ -57,6 +58,9 @@ __attribute__((noreturn)) void _entrypoint(void)
     pr_autotest("INFO: no task discover in this mode");
 #endif
     pr_info("Starting Sentry kernel release %s", "v0.1");
+#if CONFIG_EXPERIMENTAL_MODE
+    pr_info("Using experimental features! Do not use this binary in production");
+#endif
     pr_info("kernel bootup stack at %p, current frame: %p", &_bootupstack, __platform_get_current_sp());
     pr_info("booting on SoC %s", CONFIG_ARCH_SOCNAME);
     pr_info("configured dts file: %s", DTS_FILE);


### PR DESCRIPTION
For features that are merged in incremental mode, adding EXPERIMENTAL marker at  build and run time