### PR TITLE
doc: update Frama-C related documentation with last Sentry state of art

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,20 @@ Once meson build directory is setup, the build step is as simple as calling ninj
 ninja -C builddir
 ```
 
-## proof
+## formal proofness
 
-Sentry kernel proof is supported by Frama-C framework. It is based on the
+Sentry kernel formal proofness is supported by Frama-C framework. It is based on the
 analysis of the libsentry sources, which include all the kernel drivers,
 services, etc. except the kernel entrypoint.
 
-**INFO**: the Frama-C framework used is Cobalt (27), with why3 and cvc4. Meson check that they are installed on the system.
+EVA and RTE Frama-C plugins are used in order to validate that the kernel sources do not hold any run-time errors nor undefined behavior in the
+overall coverage kernel code (approx. 98%, exluding some defensive unreachable code blocks and assembly calls).
+
+In the same way, WP plugin is used in order to validate the correctness of some subparts of the Sentry kernel. The goal here is to validate that the attended behavior
+and border effects match the specifications. The way Frama-C analysis is made is designed in order to allow composition (separated per-module formal proofness in
+order to demonstrate the correctness of each module interface, while proving a module is made considering external interfaces specification as valid by hypothesis).
+
+**INFO**: the Frama-C framework requires at least Frama-C Cobalt (27), with why3 and cvc4. Meson check that they are installed on the system.
 
 Frama-C targets are hosted in the `proof` directory and are activable using
 the `with_proof` option:

--- a/doc/concepts/proof/basics.rst
+++ b/doc/concepts/proof/basics.rst
@@ -62,7 +62,7 @@ By now the following tests exist:
    * frama-c-eva-entrypoint: Execute value analysis of the kernel entrypoint, using the effective ``_entrypoint`` kernel
      startup function directly
    * frama-c-eva-handler-systick: Execute value analyis on the Systick handler, using directly the effective handler implementation as entrypoint
-   * frama-c-handler-svc: Execut value analyis on the SVC (syscall) handler, using directly the SVC handler as entrypoint
+   * frama-c-handler-svc: Executed value analyis on the SVC (syscall) handler, using directly the SVC handler as entrypoint
 
 The coverage calculation is made at analysis time to demonstrate a proper coverage of all callable programs starting with
 the given entrypoint.
@@ -73,7 +73,12 @@ the given entrypoint.
 
 .. note::
   Once coverage reaches 100% for all kernel potential entrypoint, all executable kernel code is reached and the analysis is then complete with
-  no missing part
+  no missing part, excluding only the assembly code, which is not analyzed by Frama-C
+
+To this noRTE analysis, a set of WP tests are added, in order to demonstrate the correctness of the kernel components.
+These tests are made on smaller components, starting with the kernel zlib, which is the kernel utility library.
+The goal is to demonstrate that the overall kernel components are correct, meaning that they do what they are required to do,
+and not only being exempted of RTE.
 
 When launching Frama-C analysis, a directory is forged for each test in the build directory.
 Once executed, the corresponding Frama-C analysis is hold and accessible through multiple generated files:
@@ -113,3 +118,15 @@ the way to specify, implement and separate various kernel sub-components:
 
 Once these requirements fulfill, it is highly easier to validate memory manipulation, detect Run-Time Errors and reduce
 false positives.
+
+
+In order to simplify the usage of Frama-C in the Sentry kernel, a dedicated library is provided, denoted `libproof`.
+This library provides a set of macros and functions that simplify the writing of EVA entrypoints, ACSL annotations and so on.
+This library is available in the ``kernel/proof/libproof`` directory, and is automatically included in all Frama-C tests.
+
+Frama-C testing is separated in three main parts:
+
+   * entrypoint coverage, set in the `kernel/proof/proof_entrypoint` directory, that ensures that kernel entrypoint is covered and analysed
+   * handlers coverage, set in the `kernel/proof/proof_handlers` directory, that ensures that all kernel handlers (ticker, syscalls...)
+     are covered and analysed
+   * composition tests, in order to ensure correcness of various components separatedly, hosted in the `kernel/proof/proof_composition` directory.


### PR DESCRIPTION
Adding more explanation about the way Frama-C is used in the README and add explanation about libproof formal profness utility library