### PR TITLE
kernel,sysgate: adding autotest-only capability control

### DIFF
--- a/kernel/include/sentry/arch/asm-generic/handler-svc-lut.h
+++ b/kernel/include/sentry/arch/asm-generic/handler-svc-lut.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2023 Ledger SAS
+// SPDX-FileCopyrightText: 2025 H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef HANDLER_LUT_H
@@ -15,5 +16,7 @@ typedef stack_frame_t* (*lut_svc_handler)(stack_frame_t *);
 lut_svc_handler const *svc_lut_get(void);
 
 size_t svc_lut_size(void);
+
+stack_frame_t *lut_unsuported(stack_frame_t *frame);
 
 #endif/*!HANDLER_LUT_H*/

--- a/kernel/include/sentry/managers/security.h
+++ b/kernel/include/sentry/managers/security.h
@@ -36,6 +36,10 @@ secure_bool_t mgr_security_has_oneof_capas(taskh_t tsk, uint32_t capas);
 
 #ifdef CONFIG_BUILD_TARGET_AUTOTEST
 kstatus_t mgr_security_autotest(void);
+
+kstatus_t mgr_security_set_capa(capability_t);
+
+kstatus_t mgr_security_clear_capa(capability_t);
 #endif
 
 #ifdef __cplusplus

--- a/kernel/include/sentry/managers/security.h
+++ b/kernel/include/sentry/managers/security.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Ledger SAS
+// SPDX-FileCopyrightText: 2025 H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef SECURITY_MANAGER_H

--- a/kernel/include/sentry/syscalls.h
+++ b/kernel/include/sentry/syscalls.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Ledger SAS
+// SPDX-FileCopyrightText: 2025 H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef SYSCALLS_H

--- a/kernel/include/sentry/syscalls.h
+++ b/kernel/include/sentry/syscalls.h
@@ -83,4 +83,10 @@ stack_frame_t *gate_dma_suspend(stack_frame_t *frame, dmah_t dmah);
 
 stack_frame_t *gate_dma_resume(stack_frame_t *frame, dmah_t dmah);
 
+#if CONFIG_BUILD_TARGET_AUTOTEST
+stack_frame_t *gate_autotest_set_self_capa(stack_frame_t *frame, uint32_t capa);
+
+stack_frame_t *gate_autotest_clear_self_capa(stack_frame_t *frame, uint32_t capa);
+#endif
+
 #endif/*!SYSCALLS_H*/

--- a/kernel/include/sentry/syscalls.h
+++ b/kernel/include/sentry/syscalls.h
@@ -84,8 +84,18 @@ stack_frame_t *gate_dma_suspend(stack_frame_t *frame, dmah_t dmah);
 stack_frame_t *gate_dma_resume(stack_frame_t *frame, dmah_t dmah);
 
 #if CONFIG_BUILD_TARGET_AUTOTEST
+/**
+ * @brief set a given capability to autotest
+ *
+ * NOTE: only one capability at a time is allowed.
+ */
 stack_frame_t *gate_autotest_set_self_capa(stack_frame_t *frame, uint32_t capa);
 
+/**
+ * @brief clear a given capability from autotest
+ *
+ * NOTE: only one capability at a time is allowed.
+ */
 stack_frame_t *gate_autotest_clear_self_capa(stack_frame_t *frame, uint32_t capa);
 #endif
 

--- a/kernel/include/sentry/syscalls.h
+++ b/kernel/include/sentry/syscalls.h
@@ -87,14 +87,14 @@ stack_frame_t *gate_dma_resume(stack_frame_t *frame, dmah_t dmah);
 /**
  * @brief set a given capability to autotest
  *
- * NOTE: only one capability at a time is allowed.
+ * @note only one capability at a time is allowed.
  */
 stack_frame_t *gate_autotest_set_self_capa(stack_frame_t *frame, uint32_t capa);
 
 /**
  * @brief clear a given capability from autotest
  *
- * NOTE: only one capability at a time is allowed.
+ * @note only one capability at a time is allowed.
  */
 stack_frame_t *gate_autotest_clear_self_capa(stack_frame_t *frame, uint32_t capa);
 #endif

--- a/kernel/src/arch/asm-cortex-m/handler-svc-lut.c
+++ b/kernel/src/arch/asm-cortex-m/handler-svc-lut.c
@@ -214,6 +214,18 @@ static stack_frame_t *lut_dma_stream_resume(stack_frame_t *frame) {
     return gate_dma_resume(frame, dma);
 }
 
+#if CONFIG_BUILD_TARGET_AUTOTEST
+static stack_frame_t *lut_autotest_set_self_capa(stack_frame_t *frame) {
+    uint32_t capa = frame->r0;
+    return gate_autotest_set_self_capa(frame, capa);
+}
+
+static stack_frame_t *lut_autotest_clear_self_capa(stack_frame_t *frame) {
+    uint32_t capa = frame->r0;
+    return gate_autotest_clear_self_capa(frame, capa);
+}
+#endif
+
 /* for not yet supported syscalls */
 static stack_frame_t *lut_unsuported(stack_frame_t *frame) {
     mgr_task_set_sysreturn(sched_get_current(), STATUS_NO_ENTITY);
@@ -259,6 +271,10 @@ static const lut_svc_handler svc_lut[] = {
     lut_dma_unassign,
     lut_dma_get_stream_info,
     lut_dma_stream_resume,
+#if CONFIG_BUILD_TARGET_AUTOTEST
+    lut_autotest_set_self_capa,
+    lut_autotest_clear_self_capa,
+#endif
 };
 
 #define SYSCALL_NUM ARRAY_SIZE(svc_lut)

--- a/kernel/src/arch/asm-cortex-m/handler-svc-lut.c
+++ b/kernel/src/arch/asm-cortex-m/handler-svc-lut.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Ledger SAS
+// SPDX-FileCopyrightText: 2025 H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 #include <sentry/arch/asm-generic/thread.h>

--- a/kernel/src/arch/asm-cortex-m/handler-svc-lut.c
+++ b/kernel/src/arch/asm-cortex-m/handler-svc-lut.c
@@ -227,8 +227,16 @@ static stack_frame_t *lut_autotest_clear_self_capa(stack_frame_t *frame) {
 #endif
 
 /* for not yet supported syscalls */
-static stack_frame_t *lut_unsuported(stack_frame_t *frame) {
+stack_frame_t *lut_unsuported(stack_frame_t *frame) {
+#ifdef CONFIG_BUILD_TARGET_AUTOTEST
     mgr_task_set_sysreturn(sched_get_current(), STATUS_NO_ENTITY);
+#else
+    /*
+     * in nominal mode, a task that triggers an unsupported syscall is
+     * terminated (gracefully), as this is an abnormal behavior
+     */
+    mgr_task_set_state(sched_get_current(), JOB_STATE_ABORTING);
+#endif
     return frame;
 }
 
@@ -274,6 +282,9 @@ static const lut_svc_handler svc_lut[] = {
 #if CONFIG_BUILD_TARGET_AUTOTEST
     lut_autotest_set_self_capa,
     lut_autotest_clear_self_capa,
+#else
+    lut_unsuported, /* SYSCALL_AUTOTEST_SET_CAPA */
+    lut_unsuported, /* SYSCALL_AUTOTEST_CLEAR_CAPA */
 #endif
 };
 

--- a/kernel/src/arch/asm-cortex-m/handler.c
+++ b/kernel/src/arch/asm-cortex-m/handler.c
@@ -212,7 +212,8 @@ stack_frame_t *svc_handler(stack_frame_t *frame)
     syscall_id = Frama_C_entropy_source_u8;
 #endif
     if (unlikely(syscall_id >= svc_lut_size())) {
-        mgr_task_set_sysreturn(sched_get_current(), STATUS_INVALID);
+
+        lut_unsuported(frame);
         goto err;
     }
     svc_lut = svc_lut_get();

--- a/kernel/src/arch/asm-cortex-m/handler.c
+++ b/kernel/src/arch/asm-cortex-m/handler.c
@@ -212,7 +212,6 @@ stack_frame_t *svc_handler(stack_frame_t *frame)
     syscall_id = Frama_C_entropy_source_u8;
 #endif
     if (unlikely(syscall_id >= svc_lut_size())) {
-
         lut_unsuported(frame);
         goto err;
     }

--- a/kernel/src/arch/asm-rv32/handler-svc-lut.c
+++ b/kernel/src/arch/asm-rv32/handler-svc-lut.c
@@ -232,12 +232,12 @@ static stack_frame_t *lut_dma_stream_resume(stack_frame_t *frame) {
 
 #if CONFIG_BUILD_TARGET_AUTOTEST
 static stack_frame_t *lut_autotest_set_self_capa(stack_frame_t *frame) {
-    uint32_t capa = frame->r0;
+    uint32_t capa = frame->a0;
     return gate_autotest_set_self_capa(frame, capa);
 }
 
 static stack_frame_t *lut_autotest_clear_self_capa(stack_frame_t *frame) {
-    uint32_t capa = frame->r0;
+    uint32_t capa = frame->a0;
     return gate_autotest_clear_self_capa(frame, capa);
 }
 #endif

--- a/kernel/src/managers/security/security.c
+++ b/kernel/src/managers/security/security.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Ledger SAS
+// SPDX-FileCopyrightText: 2025 H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stddef.h>

--- a/kernel/src/syscalls/meson.build
+++ b/kernel/src/syscalls/meson.build
@@ -37,6 +37,11 @@ syscalls = files(
 )
 
 syscall_source_set.add(syscalls)
+
+if kconfig_data.get('CONFIG_BUILD_TARGET_AUTOTEST', 0) == 1
+    syscall_source_set.add(files('sysgate_autotest.c'))
+endif
+
 syscall_source_set_config = syscall_source_set.apply(kconfig_data, strict:false)
 
 sentry_syscall_lib = static_library('sentry_syscall',

--- a/kernel/src/syscalls/meson.build
+++ b/kernel/src/syscalls/meson.build
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023-2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab OSS Team
 # SPDX-License-Identifier: Apache-2.0
 
 syscall_source_set = ssmod.source_set()

--- a/kernel/src/syscalls/meson.build
+++ b/kernel/src/syscalls/meson.build
@@ -39,9 +39,7 @@ syscalls = files(
 
 syscall_source_set.add(syscalls)
 
-if kconfig_data.get('CONFIG_BUILD_TARGET_AUTOTEST', 0) == 1
-    syscall_source_set.add(files('sysgate_autotest.c'))
-endif
+syscall_source_set.add(when: 'CONFIG_BUILD_TARGET_AUTOTEST', if_true: files('sysgate_autotest.c'))
 
 syscall_source_set_config = syscall_source_set.apply(kconfig_data, strict:false)
 

--- a/kernel/src/syscalls/sysgate_autotest.c
+++ b/kernel/src/syscalls/sysgate_autotest.c
@@ -4,19 +4,33 @@
 #include <sentry/arch/asm-generic/thread.h>
 #include <sentry/ktypes.h>
 #include <sentry/managers/task.h>
+#include <sentry/managers/security.h>
 #include <sentry/sched.h>
+#include <sentry/zlib/math.h>
 
 
 stack_frame_t *gate_autotest_set_self_capa(stack_frame_t *frame, uint32_t capa)
 {
     taskh_t current = sched_get_current();
+    if (!IS_POW2(capa)) {
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    mgr_security_set_capa(capa);
     mgr_task_set_sysreturn(current, STATUS_OK);
+end:
     return frame;
 }
 
 stack_frame_t *gate_autotest_clear_self_capa(stack_frame_t *frame, uint32_t capa)
 {
     taskh_t current = sched_get_current();
+    if (!IS_POW2(capa)) {
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    mgr_security_clear_capa(capa);
     mgr_task_set_sysreturn(current, STATUS_OK);
+end:
     return frame;
 }

--- a/kernel/src/syscalls/sysgate_autotest.c
+++ b/kernel/src/syscalls/sysgate_autotest.c
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 H2Lab OSS Team
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sentry/arch/asm-generic/thread.h>
+#include <sentry/ktypes.h>
+#include <sentry/managers/task.h>
+#include <sentry/sched.h>
+
+
+stack_frame_t *gate_autotest_set_self_capa(stack_frame_t *frame, uint32_t capa)
+{
+    taskh_t current = sched_get_current();
+    mgr_task_set_sysreturn(current, STATUS_OK);
+    return frame;
+}
+
+stack_frame_t *gate_autotest_clear_self_capa(stack_frame_t *frame, uint32_t capa)
+{
+    taskh_t current = sched_get_current();
+    mgr_task_set_sysreturn(current, STATUS_OK);
+    return frame;
+}

--- a/uapi/include/uapi/types.h
+++ b/uapi/include/uapi/types.h
@@ -249,9 +249,16 @@ typedef enum Syscall {
   SYSCALL_DMA_UNASSIGN_STREAM,
   SYSCALL_DMA_GET_STREAM_INFO,
   SYSCALL_DMA_RESUME_STREAM,
+  /*
+   * in order to preserve ABI retro-compatibility in case of new syscalls
+   * being added, we reserve 2 syscalls identifiers even not in autotest purposes.
+  */
 #if CONFIG_BUILD_TARGET_AUTOTEST
   SYSCALL_AUTOTEST_SET_CAPA,
   SYSCALL_AUTOTEST_CLEAR_CAPA,
+#else
+  SYSCALL_RESERVED_1,
+  SYSCALL_RESERVED_2,
 #endif
 } Syscall;
 

--- a/uapi/include/uapi/types.h
+++ b/uapi/include/uapi/types.h
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2023-2024 Ledger SAS
+// SPDX-FileCopyrightText: 2025 H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 /*
@@ -248,6 +249,10 @@ typedef enum Syscall {
   SYSCALL_DMA_UNASSIGN_STREAM,
   SYSCALL_DMA_GET_STREAM_INFO,
   SYSCALL_DMA_RESUME_STREAM,
+#if CONFIG_BUILD_TARGET_AUTOTEST
+  SYSCALL_AUTOTEST_SET_CAPA,
+  SYSCALL_AUTOTEST_CLEAR_CAPA,
+#endif
 } Syscall;
 
 /**

--- a/uapi/src/ffi_c.rs
+++ b/uapi/src/ffi_c.rs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2023 Ledger SAS
-// SPDX-FileCopyrightText: 2025 ANSSI
+// SPDX-FileCopyrightText: 2025 ANSSI & H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::exchange;
@@ -235,6 +235,20 @@ pub extern "C" fn __sys_dma_get_stream_info(dmah: StreamHandle) -> Status {
 #[unsafe(no_mangle)]
 pub extern "C" fn __sys_dma_resume_stream(dmah: StreamHandle) -> Status {
     crate::syscall::dma_resume_stream(dmah)
+}
+
+/// C interface to [`crate::syscall::autotest_set_capa`] syscall Rust implementation
+#[cfg(CONFIG_BUILD_TARGET_AUTOTEST)]
+#[unsafe(no_mangle)]
+pub extern "C" fn __sys_autotest_set_capa(capa: u32) -> Status {
+    crate::syscall::autotest_set_capa(capa)
+}
+
+/// C interface to [`crate::syscall::autotest_clear_capa`] syscall Rust implementation
+#[cfg(CONFIG_BUILD_TARGET_AUTOTEST)]
+#[unsafe(no_mangle)]
+pub extern "C" fn __sys_autotest_clear_capa(capa: u32) -> Status {
+    crate::syscall::autotest_clear_capa(capa)
 }
 
 /// # Safety

--- a/uapi/src/syscall.rs
+++ b/uapi/src/syscall.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2023 Ledger SAS
+// SPDX-FileCopyrightText: 2025 H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::exchange;
@@ -842,6 +843,22 @@ pub fn dma_get_stream_info(dmah: StreamHandle) -> Status {
 #[inline(always)]
 pub fn dma_resume_stream(dmah: StreamHandle) -> Status {
     syscall!(Syscall::DmaResumeStream, dmah).into()
+}
+
+/// Set (enable) given capability for autotest
+/// Only autotest has the userspace knowledge of the capabilities effective values
+#[cfg(CONFIG_BUILD_TARGET_AUTOTEST)]
+#[inline(always)]
+pub fn autotest_set_capa(capability: u32) -> Status {
+    syscall!(Syscall::AutotestSetCapa, capability).into()
+}
+
+/// Clear (disable) given capability for autotest
+/// Only autotest has the userspace knowledge of the capabilities effective values
+#[cfg(CONFIG_BUILD_TARGET_AUTOTEST)]
+#[inline(always)]
+pub fn autotest_clear_capa(capability: u32) -> Status {
+    syscall!(Syscall::AutotestClearCapa, capability).into()
 }
 
 #[cfg(test)]

--- a/uapi/src/systypes.rs
+++ b/uapi/src/systypes.rs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2023 Ledger SAS
-// SPDX-FileCopyrightText: 2025 ANSSI
+// SPDX-FileCopyrightText: 2025 ANSSI & H2Lab OSS Team
 // SPDX-License-Identifier: Apache-2.0
 
 /// This library defines types (structs, enums, ...) related to syscalls,
@@ -53,6 +53,8 @@ macro_rules! syscall_list {
     }
 }
 
+// FIXME: #[cfg()] does not seems to be supported with macro rules....
+// We need to find a way to make the last two autotest_ syscalls conditionally declared
 syscall_list! {
 pub enum Syscall {
     Exit,
@@ -93,6 +95,8 @@ pub enum Syscall {
     DmaUnassignStream,
     DmaGetStreamInfo,
     DmaResumeStream,
+    AutotestSetCapa,
+    AutotestClearCapa,
 }
 }
 


### PR DESCRIPTION
support for autotest-exclusive capability set/clear API in order to validate capability check at kernel level.
Note: the added syscalls are specific to autotest mode, which is mutually exclusive with other modes, in which the kernel is in standalone mode with autotest and idle tasks and never analyse nor execute any other project-relative userspace tasks.

These syscalls allow autotest to set and clear task capabilities to validate that a capability check failure always finishes with a STATUS_DENIED.

In order to allow such a model, a dedicated non-const field is used to store the current capability set value. In other modes, this field does not exist.

- [x] support for LUT-level autotest-specific syscalls in autotest mode only
- [x] support for autotest capa set/clear syscalls in sysgate
- [x] support for security-manager level capability set/clear in autotest mode only 
- [x] support for UAPI level capability set/clear syscalls

Closes #51