### PR TITLE
proof: fixing DMA handle translation assertion

### DIFF
--- a/kernel/src/managers/dma/dma.h
+++ b/kernel/src/managers/dma/dma.h
@@ -89,7 +89,7 @@ static inline const kdmah_t *dmah_to_kdmah(const dmah_t * const dh) {
   * @return converted handler pointer to opaque value
   */
 static inline const dmah_t *kdmah_to_dmah(const kdmah_t * const kdh) {
-    /*@ assert \valid(kdh); */
+    /*@ assert \valid_read(kdh); */
     union udmah converter = {
         .kdh = kdh
     };


### PR DESCRIPTION
fixing lazy assert on memory cell properties to real required value (from valid to valid_read)