### PR TITLE
workflow: add nucleo u5a5 autotest-rs in pr event matrix build

### DIFF
--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -31,6 +31,7 @@ jobs:
             toolchain = [ 'gcc|12.3.Rel1', 'gcc|10.3-2021.07', 'gcc|13.2.Rel1', 'gcc|14.2.Rel1' ]
             config = [
               { 'name': 'nucleo_u5a5_autotest', 'cpu': 'cm33', 'triple': 'thumbv8m.main-none-eabi' },
+              { 'name': 'nucleo_u5a5_autotest_rs', 'cpu': 'cm33', 'triple': 'thumbv8m.main-none-eabi' },
               { 'name': 'nucleo_u5a5_autotest_harden', 'cpu': 'cm33', 'triple': 'thumbv8m.main-none-eabi' },
               { 'name': 'nucleo_u5a5_nooutput', 'cpu': 'cm33', 'triple': 'thumbv8m.main-none-eabi' },
               { 'name': 'nucleo_wb55_autotest', 'cpu': 'cm4', 'triple': 'thumbv7em-none-eabi' },


### PR DESCRIPTION
Should fail.
autotest-rs build was missing and NOK.
This PR only adds the entry in the build matrix