### PR TITLE
autotest: fix autotest rust build

### DIFF
--- a/autotest/rust/src/devices_dt.rs.in
+++ b/autotest/rust/src/devices_dt.rs.in
@@ -11,7 +11,7 @@
 {% endmacro -%}
 
 #![allow(non_upper_case_globals)]
-use sentry_uapi::systypes::dev::{DevInfo, InterruptInfo, IoInfo};
+use sentry_uapi::systypes::dev::{DevInfo};
 use sentry_uapi::systypes::shm::ShmInfo;
 
 /// Liste des identifiants symboliques des périphériques

--- a/autotest/rust/src/devices_dt.rs.in
+++ b/autotest/rust/src/devices_dt.rs.in
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 {% macro device_get_owner(device) -%}
-{% if device["outpost,owner"] -%}
-{{ "0x%x"|format(device["outpost,owner"]) }}
+{% if device["sentry,owner"] -%}
+{{ "0x%x"|format(device["sentry,owner"]) }}
 {% else -%}
 {{ "0x%x"|format(0) }}
 {% endif -%}
 {% endmacro -%}
 
 #![allow(non_upper_case_globals)]
-use sentry_uapi::systypes::dev::{DevInfo};
+use sentry_uapi::systypes::dev::{DevInfo, InterruptInfo, IoInfo};
 use sentry_uapi::systypes::shm::ShmInfo;
 
 /// Liste des identifiants symboliques des périphériques
@@ -87,10 +87,10 @@ pub static DEVICE_NAMES: &[&str] = &[
 pub static SHMS: &[ShmInfo] = &[
 
 {%- for node in dts.get_mappable() -%}
-{% if node|has_property("outpost,shm") -%}
+{% if node|has_property("sentry,shm") -%}
     ShmInfo {
         handle: 0,
-        {% set label = node["outpost,label"] -%}
+        {% set label = node["sentry,label"] -%}
         label: {{ "0x%x"|format(label) }},
         {% if node.reg -%}
         base: {{ "0x%08x"|format(node.reg[0]) }},
@@ -99,7 +99,7 @@ pub static SHMS: &[ShmInfo] = &[
         base: 0,
         len: 0,
         {% endif -%}
-        perms: {% if node["outpost,perms"] %}{{ "0x%x"|format(node["outpost,perms"]) }}{% else -%}0{% endif -%},
+        perms: {% if node["sentry,perms"] %}{{ "0x%x"|format(node["sentry,perms"]) }}{% else -%}0{% endif -%},
     },
 {% endif -%}
 {%- endfor %}
@@ -107,7 +107,7 @@ pub static SHMS: &[ShmInfo] = &[
 
 pub static SHM_NAMES: &[&str] = &[
 {% for node in dts.get_mappable() -%}
-{%- if node|has_property("outpost,shm") %}
+{%- if node|has_property("sentry,shm") %}
     "{{ node.label }}",
 {%- endif %}
 {%- endfor %}

--- a/autotest/rust/src/tests/test_dma.rs
+++ b/autotest/rust/src/tests/test_dma.rs
@@ -275,15 +275,15 @@ fn test_dma_get_info() -> bool {
     };
 
     ok &= check_eq!(syscall::get_shm_handle(shm), Status::Ok);
-    ok &= copy_from_kernel(&mut (&mut shm as *mut _ as *mut u8)) == Ok(Status::Ok);
+    ok &= copy_from_kernel(&mut shm) == Ok(Status::Ok);
     ok &= check_eq!(syscall::shm_get_infos(shm), Status::Ok);
-    ok &= copy_from_kernel(&mut (&mut infos as *mut _ as *mut u8)) == Ok(Status::Ok);
+    ok &= copy_from_kernel(&mut infos) == Ok(Status::Ok);
 
     ok &= check_eq!(syscall::get_dma_stream_handle(0x1), Status::Ok);
-    ok &= copy_from_kernel(&mut (&mut streamh as *mut _ as *mut u8)) == Ok(Status::Ok);
+    ok &= copy_from_kernel(&mut streamh) == Ok(Status::Ok);
 
     ok &= check_eq!(syscall::dma_get_stream_info(streamh), Status::Ok);
-    ok &= copy_from_kernel(&mut (&mut stream_info as *mut _ as *mut u8)) == Ok(Status::Ok);
+    ok &= copy_from_kernel(&mut stream_info) == Ok(Status::Ok);
 
     ok &= check_eq!(stream_info.stream, 112);
     ok &= check_eq!(stream_info.channel, 1);

--- a/autotest/rust/src/tests/test_ipc.rs
+++ b/autotest/rust/src/tests/test_ipc.rs
@@ -63,7 +63,7 @@ fn test_ipc_sendrecv() -> bool {
     let mut status;
     let mut handle: systypes::TaskHandle = 0;
     let timeout: i32 = 100;
-    let msg = b"hello it's autotest";
+    let msg = "hello it's autotest";
     let mut data = [0u8; CONFIG_SVC_EXCHANGE_AREA_LEN];
 
     status = syscall::get_process_handle(0xbabe);
@@ -74,12 +74,12 @@ fn test_ipc_sendrecv() -> bool {
     log_line!(USER_AUTOTEST_INFO, "sending IPC to myself");
 
     // Emit IPC
-    let _ = sentry_uapi::copy_to_kernel(&(msg.as_ptr() as *mut u8));
+    let _ = sentry_uapi::copy_to_kernel(&(msg.as_bytes()));
     status = syscall::send_ipc(handle, 20);
     ok &= check_eq!(status, systypes::Status::Ok);
     // Recive IPC
     status = syscall::wait_for_event(systypes::EventType::Ipc as u8, timeout);
-    ok &= sentry_uapi::copy_from_kernel(&mut data.as_mut_ptr()) == Ok(systypes::Status::Ok);
+    ok &= sentry_uapi::copy_from_kernel(&mut (&mut data[..])) == Ok(systypes::Status::Ok);
     assert_eq!(status, systypes::Status::Ok);
 
     let header = unsafe { &*(data.as_ptr() as *const systypes::ExchangeHeader) };
@@ -104,7 +104,7 @@ fn test_ipc_deadlock() -> bool {
     let mut ok = true;
     let mut handle: systypes::TaskHandle = 0;
     let status;
-    let msg = b"hello it's autotest";
+    let msg = "hello it's autotest";
 
     status = syscall::get_process_handle(0xbabe);
     let _ = sentry_uapi::copy_from_kernel(&mut handle);
@@ -112,7 +112,7 @@ fn test_ipc_deadlock() -> bool {
     assert_eq!(status, systypes::Status::Ok);
 
     log_line!(USER_AUTOTEST_INFO, "sending IPC to myself");
-    let _ = sentry_uapi::copy_to_kernel(&(msg.as_ptr() as *mut u8));
+    let _ = sentry_uapi::copy_to_kernel(&(msg.as_bytes()));
     ok &= check_eq!(syscall::send_ipc(handle, 20), systypes::Status::Ok);
     log_line!(
         USER_AUTOTEST_INFO,

--- a/uapi/src/exchange.rs
+++ b/uapi/src/exchange.rs
@@ -81,6 +81,48 @@ impl SentryExchangeable for crate::systypes::shm::ShmInfo {
     }
 }
 
+/// SentryExchangeable trait implementation for dma::GpdmaStreamConfig.
+/// dma::GpdmaStreamConfig is a typical structure which is returned by the kernel to the
+/// userspace in order to delivers various DMA stream-related information to a given
+/// task that is using the corresponding DMA handle.
+///
+/// In test mode only, this structure can be written back to the Exchange Area.
+/// In production mode, the application can't write such a content to the exchange
+/// as the kernel as strictly no use of it.
+///
+impl SentryExchangeable for crate::systypes::dma::GpdmaStreamConfig {
+    #[allow(static_mut_refs)]
+    fn from_kernel(&mut self) -> Result<Status, Status> {
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                EXCHANGE_AREA.as_ptr(),
+                addr_of_mut!(*self) as *mut u8,
+                core::mem::size_of::<crate::systypes::dma::GpdmaStreamConfig>().min(EXCHANGE_AREA_LEN),
+            );
+        }
+        Ok(Status::Ok)
+    }
+
+    #[cfg(test)]
+    #[allow(static_mut_refs)]
+    fn to_kernel(&self) -> Result<Status, Status> {
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                addr_of!(*self) as *const u8,
+                EXCHANGE_AREA.as_mut_ptr(),
+                core::mem::size_of::<crate::systypes::dma::GpdmaStreamConfig>().min(EXCHANGE_AREA_LEN),
+            );
+        }
+        Ok(Status::Ok)
+    }
+
+    #[cfg(not(test))]
+    #[allow(static_mut_refs)]
+    fn to_kernel(&self) -> Result<Status, Status> {
+        Err(Status::Invalid)
+    }
+}
+
 /// SentryExchangeable trait implementation for Scalar types.
 ///
 macro_rules! impl_exchangeable {

--- a/uapi/src/exchange.rs
+++ b/uapi/src/exchange.rs
@@ -97,7 +97,8 @@ impl SentryExchangeable for crate::systypes::dma::GpdmaStreamConfig {
             core::ptr::copy_nonoverlapping(
                 EXCHANGE_AREA.as_ptr(),
                 addr_of_mut!(*self) as *mut u8,
-                core::mem::size_of::<crate::systypes::dma::GpdmaStreamConfig>().min(EXCHANGE_AREA_LEN),
+                core::mem::size_of::<crate::systypes::dma::GpdmaStreamConfig>()
+                    .min(EXCHANGE_AREA_LEN),
             );
         }
         Ok(Status::Ok)
@@ -110,7 +111,8 @@ impl SentryExchangeable for crate::systypes::dma::GpdmaStreamConfig {
             core::ptr::copy_nonoverlapping(
                 addr_of!(*self) as *const u8,
                 EXCHANGE_AREA.as_mut_ptr(),
-                core::mem::size_of::<crate::systypes::dma::GpdmaStreamConfig>().min(EXCHANGE_AREA_LEN),
+                core::mem::size_of::<crate::systypes::dma::GpdmaStreamConfig>()
+                    .min(EXCHANGE_AREA_LEN),
             );
         }
         Ok(Status::Ok)


### PR DESCRIPTION
autotest-rs copy_from/copy_to usage used old, no more supported *mut[u8] argument passing from generic kernel<->user exchanges such as IPC messages. Using &mut[u8] instead.
Adding missing `uapi::systypes::dma::GpdmaStreamConfig`exchangeable type (form_kernel only) implementation of the SentryExchangeable trait.

autotest-rs do build but still panic later on. This panic() need also to be fixed. This PR update may be the source of the panic() but not convinced though.