### PR TITLE
fix: using generic headers when not arch or driver

### DIFF
--- a/kernel/include/sentry/arch/asm-cortex-m/dwt.h
+++ b/kernel/include/sentry/arch/asm-cortex-m/dwt.h
@@ -17,6 +17,8 @@ __STATIC_FORCEINLINE void dwt_enable_cyccnt(void)
     DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 }
 
+__STATIC_FORCEINLINE void platform_enable_cyccnt(void)__attribute__((alias("dwt_enable_cyccnt")));
+
 /*@
   assigns DWT->CTRL;
  */
@@ -24,6 +26,8 @@ __STATIC_FORCEINLINE void dwt_disable_cyccnt(void)
 {
     DWT->CTRL &= ~DWT_CTRL_CYCCNTENA_Msk;
 }
+
+__STATIC_FORCEINLINE void platform_disable_cyccnt(void)__attribute__((alias("dwt_disable_cyccnt")));
 
 /*@
   assigns DWT->CYCCNT;
@@ -33,6 +37,8 @@ __STATIC_FORCEINLINE void dwt_reset_cyccnt(void)
     DWT->CYCCNT = 0;
 }
 
+__STATIC_FORCEINLINE void platform_reset_cyccnt(void)__attribute__((alias("dwt_reset_cyccnt")));
+
 /*@
   assigns \nothing;
  */
@@ -40,5 +46,7 @@ __STATIC_FORCEINLINE uint32_t dwt_cyccnt(void)
 {
     return DWT->CYCCNT;
 }
+
+__STATIC_FORCEINLINE uint32_t platform_get_cyccnt(void)__attribute__((alias("dwt_cyccnt")));
 
 #endif /* __ARCH_PERFO_H */

--- a/kernel/include/sentry/arch/asm-generic/platform.h
+++ b/kernel/include/sentry/arch/asm-generic/platform.h
@@ -11,6 +11,7 @@
 
 #if defined(__arm__) || defined(__FRAMAC__)
 #include <sentry/arch/asm-cortex-m/platform.h>
+#include <sentry/arch/asm-cortex-m/dwt.h>
 #elif defined(__x86_64__)
 #include <sentry/arch/asm-x86_64/platform.h>
 #elif defined(CONFIG_ARCH_RV32)

--- a/kernel/src/managers/clock/perfo.c
+++ b/kernel/src/managers/clock/perfo.c
@@ -3,11 +3,7 @@
 
 #include <inttypes.h>
 
-#if defined(__arm__)
-/* need DWT backend for cycle count */
-#include <sentry/arch/asm-cortex-m/core.h>
-#include <sentry/arch/asm-cortex-m/dwt.h>
-#endif
+#include <sentry/arch/asm-generic/platform.h>
 #include <bsp/drivers/clk/rcc.h>
 
 static uint32_t perfo_cycle_per_usec;


### PR DESCRIPTION
Removing arch-specific ifdef in perfo generic support.
This remove the last usage of ifdef on arch type in managers, using arch-generic header instead.
This enhance the ability of the kernel to be fully multi-arch compliant.

Closes #44 
