### PR TITLE
sec: support for domain filtering

### DIFF
--- a/kernel/include/sentry/managers/task.h
+++ b/kernel/include/sentry/managers/task.h
@@ -105,6 +105,8 @@ kstatus_t mgr_task_get_state(taskh_t t, job_state_t *state);
 
 kstatus_t mgr_task_get_metadata(taskh_t t, const task_meta_t **tsk_meta);
 
+kstatus_t mgr_task_get_domain(taskh_t t, uint8_t *domain);
+
 kstatus_t mgr_task_get_handle(uint32_t label, taskh_t *handle);
 
 kstatus_t mgr_task_set_sp(taskh_t t, stack_frame_t *newsp);

--- a/kernel/src/managers/task/task_core.c
+++ b/kernel/src/managers/task/task_core.c
@@ -287,6 +287,24 @@ end:
     return status;
 }
 
+/**
+ * @fn return task domain for a given task handler
+ */
+kstatus_t mgr_task_get_domain(taskh_t t, uint8_t *domain)
+{
+    kstatus_t status = K_ERROR_INVPARAM;
+    task_t * tsk = task_get_from_handle(t);
+    if (unlikely(tsk == NULL || domain == NULL)) {
+        goto end;
+    }
+    /*@ assert \valid_read(tsk->metadata); */
+    /*@ assert \valid(domain); */
+    *domain = tsk->metadata->domain;
+    status = K_STATUS_OKAY;
+end:
+    return status;
+}
+
 /*
  * Forge a stack context
  */


### PR DESCRIPTION
A job is no more allowed to get back a task handle of another job if they are not in the same domain. task handles are now domain-confidentials.
This PR is a first step toward #56 