### PR TITLE
secu: enforce reset on userspace fault detection

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -170,5 +170,16 @@ config SECU_ENFORCE_FAULT_INJECTION
 	  paths with supplementary checks that whould have been dead
 	  code in nominal execution
 
+config SECU_RESET_ON_USERFAULT
+	bool "Reset system on userspace fault"
+	default n
+	---help---
+	  If any user-space task generates a fault (e.g. invalid memory access,
+	  illegal instruction, division by zero, etc), the whole system is reset for
+	  security purposes.
+	  Note that this may lead to denial of service if a faulty task is
+	  continuously executed. In the same time, it would avoid potential
+	  exploitation of such faults to escalate privileges or to leak
+	  sensitive data.
 
 endmenu

--- a/kernel/src/arch/asm-cortex-m/handler.c
+++ b/kernel/src/arch/asm-cortex-m/handler.c
@@ -84,8 +84,13 @@ __STATIC_FORCEINLINE stack_frame_t *may_panic(stack_frame_t *frame) {
          */
         pr_debug("[%lx] Userspace Oops!", tsk);
         mgr_task_set_state(tsk, JOB_STATE_FAULT);
+#ifdef CONFIG_SECU_RESET_ON_USERFAULT
+        /* force reset on userspace fault, be cautious as it can lead to DoS */
+        system_reset();
+#else
         tsk = sched_elect();
         mgr_task_get_sp(tsk, &newframe);
+#endif
     } else {
         __do_panic();
         __builtin_unreachable();


### PR DESCRIPTION
Allows automatic core reset if a given userspace task generate a fault (mem-access, usage, etc.). This option is not set by default, as, even if it avoid a potential continuation of a given exploitation phase, it also enables a potential Deny of Service.
The project integrator is then responsible for enabling or disabling this feature.

If not set, the faulty task is de-scheduled and no more scheduled while the system is not reset.