### PR TITLE
fix: fixing rust bitcode need for lto usage

### DIFF
--- a/uapi/meson.build
+++ b/uapi/meson.build
@@ -20,6 +20,7 @@ global_rust_build_args = [
     '@' + fs.parent(kconfig_rustargs) / fs.name(kconfig_rustargs),
     target_rustargs,
     '-C', 'lto=true', '-C', 'relocation-model=pic',
+    '-C', 'embed-bitcode=true',
     '-C', 'link-args=--emit-relocs',
 ]
 


### PR DESCRIPTION
in Meson 1.10, b_bitcode (apple bitcode usage) is set to false by default. Although, Rust need bitcode to be set otherwise lto support does not work (asm symbol drop problem maybe ?).
This is fixed by adding the need-bitcode=true to the rust args flags.