### PR TITLE
fix: fixing always true/always false warning due to empty lists

### DIFF
--- a/kernel/src/managers/dma/dma-dt.c.in
+++ b/kernel/src/managers/dma/dma-dt.c.in
@@ -125,10 +125,12 @@ static const dma_meta_t streams[] = {
 
 kstatus_t dma_stream_get_owner(size_t streamid, taskh_t * owner)
 {
-    kstatus_t status = K_ERROR_INVPARAM;
+    kstatus_t status;
 #if STREAM_LIST_SIZE == 0
+    status = K_ERROR_NOENT;
     goto end;
 #else
+    status = K_ERROR_INVPARAM;
     if (unlikely(streamid >= STREAM_LIST_SIZE)) {
         goto end;
     }
@@ -145,10 +147,12 @@ end:
 
 kstatus_t dma_stream_get_config(size_t streamid, gpdma_stream_cfg_t const ** cfg)
 {
-    kstatus_t status = K_ERROR_INVPARAM;
+    kstatus_t status;
 #if STREAM_LIST_SIZE == 0
+    status = K_ERROR_NOENT;
     goto end;
 #else
+    status = K_ERROR_INVPARAM;
     if (unlikely(streamid >= STREAM_LIST_SIZE)) {
         goto end;
     }
@@ -165,10 +169,12 @@ end:
 
 kstatus_t dma_stream_get_label(size_t streamid, size_t * label)
 {
-    kstatus_t status = K_ERROR_INVPARAM;
+    kstatus_t status;
 #if STREAM_LIST_SIZE == 0
+    status = K_ERROR_NOENT;
     goto end;
 #else
+    status = K_ERROR_INVPARAM;
     if (unlikely(streamid >= STREAM_LIST_SIZE)) {
         goto end;
     }
@@ -185,10 +191,12 @@ end:
 
 kstatus_t dma_stream_get_meta(size_t streamid, dma_meta_t const ** cfg)
 {
-    kstatus_t status = K_ERROR_INVPARAM;
+    kstatus_t status;
 #if STREAM_LIST_SIZE == 0
+    status = K_ERROR_NOENT;
     goto end;
 #else
+    status = K_ERROR_INVPARAM;
     if (unlikely(streamid >= STREAM_LIST_SIZE)) {
         goto end;
     }

--- a/kernel/src/managers/dma/dma-dt.c.in
+++ b/kernel/src/managers/dma/dma-dt.c.in
@@ -126,6 +126,9 @@ static const dma_meta_t streams[] = {
 kstatus_t dma_stream_get_owner(size_t streamid, taskh_t * owner)
 {
     kstatus_t status = K_ERROR_INVPARAM;
+#if STREAM_LIST_SIZE == 0
+    goto end;
+#else
     if (unlikely(streamid >= STREAM_LIST_SIZE)) {
         goto end;
     }
@@ -135,6 +138,7 @@ kstatus_t dma_stream_get_owner(size_t streamid, taskh_t * owner)
     /*@ assert \valid(owner); */
     *owner = streams[streamid].owner;
     status = K_STATUS_OKAY;
+#endif
 end:
     return status;
 }
@@ -142,6 +146,9 @@ end:
 kstatus_t dma_stream_get_config(size_t streamid, gpdma_stream_cfg_t const ** cfg)
 {
     kstatus_t status = K_ERROR_INVPARAM;
+#if STREAM_LIST_SIZE == 0
+    goto end;
+#else
     if (unlikely(streamid >= STREAM_LIST_SIZE)) {
         goto end;
     }
@@ -151,6 +158,7 @@ kstatus_t dma_stream_get_config(size_t streamid, gpdma_stream_cfg_t const ** cfg
     /*@ assert \valid(cfg); */
     *cfg = &streams[streamid].config;
     status = K_STATUS_OKAY;
+#endif
 end:
     return status;
 }
@@ -158,6 +166,9 @@ end:
 kstatus_t dma_stream_get_label(size_t streamid, size_t * label)
 {
     kstatus_t status = K_ERROR_INVPARAM;
+#if STREAM_LIST_SIZE == 0
+    goto end;
+#else
     if (unlikely(streamid >= STREAM_LIST_SIZE)) {
         goto end;
     }
@@ -167,6 +178,7 @@ kstatus_t dma_stream_get_label(size_t streamid, size_t * label)
     /*@ assert \valid(label); */
     *label = streams[streamid].label;
     status = K_STATUS_OKAY;
+#endif
 end:
     return status;
 }
@@ -174,6 +186,9 @@ end:
 kstatus_t dma_stream_get_meta(size_t streamid, dma_meta_t const ** cfg)
 {
     kstatus_t status = K_ERROR_INVPARAM;
+#if STREAM_LIST_SIZE == 0
+    goto end;
+#else
     if (unlikely(streamid >= STREAM_LIST_SIZE)) {
         goto end;
     }
@@ -183,6 +198,7 @@ kstatus_t dma_stream_get_meta(size_t streamid, dma_meta_t const ** cfg)
     /*@ assert \valid(cfg); */
     *cfg = &streams[streamid];
     status = K_STATUS_OKAY;
+#endif
 end:
     return status;
 }

--- a/kernel/src/managers/dma/dma.c
+++ b/kernel/src/managers/dma/dma.c
@@ -228,19 +228,25 @@ end:
 
 kstatus_t mgr_dma_get_status(dmah_t d, gpdma_chan_state_t *dma_status)
 {
-    kstatus_t status = K_ERROR_INVPARAM;
+    kstatus_t status;
     /*@ assert \valid(dma_status); */
 #if STREAM_LIST_SIZE == 0
+    status = K_ERROR_NOENT;
     goto end;
 #else
+    status = K_ERROR_INVPARAM;
     kdmah_t const *kdmah = dmah_to_kdmah(&d);
+
+    if (unlikely(dma_status == NULL)) {
+        goto end;
+    }
     if (kdmah->streamid >= STREAM_LIST_SIZE) {
         goto end;
     }
     if (stream_config[kdmah->streamid].handle != d) {
         goto end;
     }
-    memcpy(dma_status, &stream_config[kdmah->streamid].state, sizeof(gpdma_chan_state_t));
+    *dma_status = stream_config[kdmah->streamid].status.state;
     status = K_STATUS_OKAY;
 #endif
 end:

--- a/kernel/src/managers/dma/dma.c
+++ b/kernel/src/managers/dma/dma.c
@@ -275,7 +275,7 @@ kstatus_t mgr_dma_autotest(void)
  */
 kstatus_t mgr_dma_get_dmah_from_interrupt(const uint16_t IRQn, dmah_t *dmah)
 {
-    kstatus_t status = K_ERROR_INVPARAM;
+    kstatus_t status = K_ERROR_NOENT;
     uint16_t stream_irqn = 0;
     uint16_t stream;
     gpdma_stream_cfg_t const *cfg = NULL;
@@ -284,6 +284,7 @@ kstatus_t mgr_dma_get_dmah_from_interrupt(const uint16_t IRQn, dmah_t *dmah)
         goto end;
     }
 #if STREAM_LIST_SIZE
+    status = K_ERROR_INVPARAM;
     /* 1. get back dma {chan,ctrl} couple from IRQn */
     for (stream = 0; stream < STREAM_LIST_SIZE; ++stream) {
         cfg = &stream_config[stream].meta->config;

--- a/kernel/src/managers/dma/dma.c
+++ b/kernel/src/managers/dma/dma.c
@@ -83,6 +83,7 @@ end:
 static dma_stream_config_t *mgr_dma_get_config(const dmah_t dmah)
 {
     dma_stream_config_t * cfg = NULL;
+#if STREAM_LIST_SIZE
     for (size_t streamid = 0; streamid < STREAM_LIST_SIZE; ++streamid) {
         if (stream_config[streamid].handle == dmah) {
             cfg = &stream_config[streamid];
@@ -90,6 +91,7 @@ static dma_stream_config_t *mgr_dma_get_config(const dmah_t dmah)
         }
     }
 end:
+#endif
     return cfg;
 }
 
@@ -111,6 +113,7 @@ kstatus_t mgr_dma_get_info(const dmah_t dmah, gpdma_stream_cfg_t const ** infos)
     if (unlikely(infos == NULL)) {
         goto end;
     }
+#if STREAM_LIST_SIZE
     for (size_t streamid = 0; streamid < STREAM_LIST_SIZE; ++streamid) {
         if (stream_config[streamid].handle == dmah) {
             *infos = &stream_config[streamid].meta->config;
@@ -118,6 +121,7 @@ kstatus_t mgr_dma_get_info(const dmah_t dmah, gpdma_stream_cfg_t const ** infos)
             goto end;
         }
     }
+#endif
 end:
     return status;
 }
@@ -173,6 +177,9 @@ end:
 kstatus_t mgr_dma_get_owner(dmah_t d, taskh_t *owner)
 {
     kstatus_t status = K_ERROR_INVPARAM;
+#if STREAM_LIST_SIZE == 0
+    goto end;
+#else
     uint32_t owner_label;
     if (unlikely(owner == NULL)) {
         goto end;
@@ -186,6 +193,7 @@ kstatus_t mgr_dma_get_owner(dmah_t d, taskh_t *owner)
     }
     *owner = stream_config[kdmah->streamid].owner;
     status = K_STATUS_OKAY;
+#endif
 end:
     return status;
 }
@@ -222,7 +230,9 @@ kstatus_t mgr_dma_get_status(dmah_t d, gpdma_chan_state_t *dma_status)
 {
     kstatus_t status = K_ERROR_INVPARAM;
     /*@ assert \valid(dma_status); */
-
+#if STREAM_LIST_SIZE == 0
+    goto end;
+#else
     kdmah_t const *kdmah = dmah_to_kdmah(&d);
     if (kdmah->streamid >= STREAM_LIST_SIZE) {
         goto end;
@@ -232,6 +242,7 @@ kstatus_t mgr_dma_get_status(dmah_t d, gpdma_chan_state_t *dma_status)
     }
     memcpy(dma_status, &stream_config[kdmah->streamid].state, sizeof(gpdma_chan_state_t));
     status = K_STATUS_OKAY;
+#endif
 end:
     return status;
 }
@@ -266,6 +277,7 @@ kstatus_t mgr_dma_get_dmah_from_interrupt(const uint16_t IRQn, dmah_t *dmah)
     if (unlikely(dmah == NULL)) {
         goto end;
     }
+#if STREAM_LIST_SIZE
     /* 1. get back dma {chan,ctrl} couple from IRQn */
     for (stream = 0; stream < STREAM_LIST_SIZE; ++stream) {
         cfg = &stream_config[stream].meta->config;
@@ -284,6 +296,7 @@ kstatus_t mgr_dma_get_dmah_from_interrupt(const uint16_t IRQn, dmah_t *dmah)
     /* not found, leaving with error */
     status = K_ERROR_NOENT;
     goto end;
+#endif
 end:
     return status;
 }

--- a/kernel/src/zlib/string.c
+++ b/kernel/src/zlib/string.c
@@ -79,7 +79,6 @@ static inline char * __sentry_memset(char *s, int c, unsigned int n)
         s[i] = (c & 0xff);
         /*@ assert s[i] == (char)c; */
     }
-err:
     return s;
 }
 


### PR DESCRIPTION
When DTS-based generated lists are empty (no ressource declared), code portion that loop over the list generates always true warning (e.g. `for (i = 0; i < LIST_SIZE; ++i) {}̀̀`. While these warnings are functionally non-impactant, we remove them by removing the effective loops and control blocks on empty lists. This removal is based on the cpp value, as it is known compile time once C code is generated from the DTS fields.